### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,29 @@
 setting.py
+
+
+
+# Created by https://www.gitignore.io/api/wordpress
+
+### WordPress ###
+*.log
+wp-config.php
+wp-content/advanced-cache.php
+wp-content/backup-db/
+wp-content/backups/
+wp-content/blogs.dir/
+wp-content/cache/
+wp-content/upgrade/
+wp-content/uploads/
+wp-content/mu-plugins/
+wp-content/wp-cache-config.php
+wp-content/plugins/hello.php
+
+/.htaccess
+/license.txt
+/readme.html
+/sitemap.xml
+/sitemap.xml.gz
+
+
+
+# End of https://www.gitignore.io/api/wordpress


### PR DESCRIPTION
¿Que ha cambiado?
Agregamos al gitignore soporte para WordPress 
- [ ] Frontend
- [ ] Backend
- [x] Configuración del server

# Cómo puedo probar los cambios?
Por ejemplo los archivos y la carpeta wp-content ya no se suben al repo, ver el archivo gitignore completo
